### PR TITLE
feat(XMLExtractor): add extractSign method to retrieve the 'sign' val…

### DIFF
--- a/src/main/java/com/germanfica/wsfe/util/XMLExtractor.java
+++ b/src/main/java/com/germanfica/wsfe/util/XMLExtractor.java
@@ -76,6 +76,16 @@ public class XMLExtractor {
     }
 
     /**
+     * Extrae únicamente el valor del sign desde el XML.
+     *
+     * @return El valor del sign como String.
+     * @throws Exception Si ocurre un error al extraer el valor.
+     */
+    public String extractSign() throws Exception {
+        return extractValue("/loginTicketResponse/credentials/sign");
+    }
+
+    /**
      * Extrae únicamente el valor del token desde el XML.
      *
      * @return El valor del token como String.


### PR DESCRIPTION
…ue from loginTicketResponse XML

This method complements extractToken by enabling extraction of the 'sign' element from the credentials node. Useful for WSAA authentication workflows.