### PR TITLE
feat: add configurable HTTP transport mode and enforce HC5 for authenticated proxies

### DIFF
--- a/src/main/java/com/germanfica/wsfe/WsaaClient.java
+++ b/src/main/java/com/germanfica/wsfe/WsaaClient.java
@@ -35,11 +35,14 @@ public class WsaaClient {
         private final ApiEnvironment apiEnvironment;
         @Getter(onMethod_ = {@Override})
         private final ProxyOptions proxyOptions;
+        @Getter(onMethod_ = {@Override})
+        private final HttpTransportMode httpTransportMode;
 
-        ClientWsaaResponseGetterOptions(String urlBase, ApiEnvironment apiEnvironment, ProxyOptions proxyOptions) {
+        ClientWsaaResponseGetterOptions(String urlBase, ApiEnvironment apiEnvironment, ProxyOptions proxyOptions, HttpTransportMode httpTransportMode) {
             this.urlBase = urlBase;
             this.apiEnvironment = apiEnvironment;
             this.proxyOptions = proxyOptions;
+            this.httpTransportMode = httpTransportMode;
         }
     }
 
@@ -51,6 +54,7 @@ public class WsaaClient {
         private String urlBase;
         private ApiEnvironment apiEnvironment;
         private ProxyOptions proxyOptions;
+        private HttpTransportMode httpTransportMode;
 
         public WsaaClientBuilder setUrlBase(String urlBase) {
             this.urlBase = urlBase;
@@ -66,13 +70,22 @@ public class WsaaClient {
             this.proxyOptions = proxyOptions;
             return this;
         }
+        public WsaaClientBuilder setHttpTransportMode(HttpTransportMode httpTransportMode) {
+            this.httpTransportMode = httpTransportMode;
+            return this;
+        }
 
         public WsaaClient build() {
             return new WsaaClient(new DefaultSoapRequestHandler(buildOptions()));
         }
 
         private SoapResponseGetterOptions buildOptions() {
-            return new ClientWsaaResponseGetterOptions(this.urlBase, this.apiEnvironment, this.proxyOptions);
+            return new ClientWsaaResponseGetterOptions(
+                this.urlBase,
+                this.apiEnvironment,
+                this.proxyOptions,
+                this.httpTransportMode != null ? this.httpTransportMode : HttpTransportMode.HTTP
+            );
         }
     }
 }

--- a/src/main/java/com/germanfica/wsfe/WsfeClient.java
+++ b/src/main/java/com/germanfica/wsfe/WsfeClient.java
@@ -46,11 +46,14 @@ public class WsfeClient {
         private final ApiEnvironment apiEnvironment;
         @Getter(onMethod_ = {@Override})
         private final ProxyOptions proxyOptions;
+        @Getter(onMethod_ = {@Override})
+        private final HttpTransportMode httpTransportMode;
 
-        ClientWsfeResponseGetterOptions(String token, String sign, Long cuit, String urlBase, ApiEnvironment apiEnvironment, ProxyOptions proxyOptions) {
+        ClientWsfeResponseGetterOptions(String token, String sign, Long cuit, String urlBase, ApiEnvironment apiEnvironment, ProxyOptions proxyOptions, HttpTransportMode httpTransportMode) {
             this.urlBase = urlBase;
             this.apiEnvironment = apiEnvironment;
             this.proxyOptions = proxyOptions;
+            this.httpTransportMode = httpTransportMode;
         }
     }
 
@@ -68,9 +71,10 @@ public class WsfeClient {
         private String token;
         private String sign;
         private Long cuit;
-        private String apiBase;
-        ApiEnvironment apiEnvironment;
-        ProxyOptions proxyOptions;
+        private String urlBase;
+        private ApiEnvironment apiEnvironment;
+        private ProxyOptions proxyOptions;
+        private HttpTransportMode httpTransportMode;
 
         public WsfeClient build() {
             return new WsfeClient(new DefaultSoapRequestHandler(buildOptions()));
@@ -81,9 +85,10 @@ public class WsfeClient {
                     this.token,
                     this.sign,
                     this.cuit,
-                    this.apiBase,
+                    this.urlBase,
                     this.apiEnvironment,
-                    this.proxyOptions
+                    this.proxyOptions,
+                    this.httpTransportMode != null ? this.httpTransportMode : HttpTransportMode.HTTP
             );
         }
     }

--- a/src/main/java/com/germanfica/wsfe/examples/AuthWithProxyExample.java
+++ b/src/main/java/com/germanfica/wsfe/examples/AuthWithProxyExample.java
@@ -3,6 +3,7 @@ package com.germanfica.wsfe.examples;
 import com.germanfica.wsfe.WsaaClient;
 import com.germanfica.wsfe.cms.Cms;
 import com.germanfica.wsfe.net.ApiEnvironment;
+import com.germanfica.wsfe.net.HttpTransportMode;
 import com.germanfica.wsfe.net.ProxyOptions;
 import com.germanfica.wsfe.param.CmsParams;
 import com.germanfica.wsfe.util.*;
@@ -42,6 +43,7 @@ public class AuthWithProxyExample {
             WsaaClient client = WsaaClient.builder()
                 .setApiEnvironment(ApiEnvironment.PROD)
                 .setProxyOptions(proxyOptions)
+                //.setHttpTransportMode(HttpTransportMode.HTTP_HC5) // Add RFC 7235 support
                 .build();
 
             // 3) Invocar autenticación en WSAA

--- a/src/main/java/com/germanfica/wsfe/exception/MissingHttpTransportSupportException.java
+++ b/src/main/java/com/germanfica/wsfe/exception/MissingHttpTransportSupportException.java
@@ -1,0 +1,27 @@
+package com.germanfica.wsfe.exception;
+
+import com.germanfica.wsfe.dto.ErrorDto;
+import com.germanfica.wsfe.net.HttpStatus;
+
+import java.net.InetAddress;
+
+public class MissingHttpTransportSupportException extends ApiException {
+  public MissingHttpTransportSupportException() {
+    super(new ErrorDto(
+        "invalid_transport_mode",
+        "Transport 'HTTP_HC5' is required when using proxy with authentication (RFC 7235 support)",
+        new ErrorDto.ErrorDetailsDto(
+            "MissingHttpTransportSupportException",
+            getLocalHostname()
+        )
+    ), HttpStatus.BAD_REQUEST);
+  }
+
+  private static String getLocalHostname() {
+    try {
+      return InetAddress.getLocalHost().getHostName();
+    } catch (Exception e) {
+      return "unknown-host";
+    }
+  }
+}

--- a/src/main/java/com/germanfica/wsfe/net/HttpTransportMode.java
+++ b/src/main/java/com/germanfica/wsfe/net/HttpTransportMode.java
@@ -1,0 +1,13 @@
+package com.germanfica.wsfe.net;
+
+public enum HttpTransportMode {
+    HTTP,        // Default HTTPConduit (HttpURLConnection)
+    //HTTP_HC,   // HttpClient v4
+    HTTP_HC5,    // HttpClient v5 (async, soporta proxy con auth RFC 7235)
+    //HTTP_NETTY,
+    //HTTP_JETTY,
+    //HTTP_UNDERTOW,
+    //WEBSOCKET,
+    //JMS,
+    //UDP
+}

--- a/src/main/java/com/germanfica/wsfe/net/RequestOptions.java
+++ b/src/main/java/com/germanfica/wsfe/net/RequestOptions.java
@@ -12,14 +12,16 @@ public class RequestOptions {
     private final String urlBase;
     private final ApiEnvironment apiEnvironment;
     private final ProxyOptions proxyOptions;
+    private final HttpTransportMode httpTransportMode;
 
-    private RequestOptions(String token, String sign, Long cuit, String urlBase, ApiEnvironment apiEnvironment, ProxyOptions proxyOptions) {
+    private RequestOptions(String token, String sign, Long cuit, String urlBase, ApiEnvironment apiEnvironment, ProxyOptions proxyOptions, HttpTransportMode httpTransportMode) {
         this.token = normalizeToken(token);
         this.sign = normalizeSign(sign);
         this.cuit = cuit;
         this.urlBase = normalizeUrlBase(urlBase);
         this.apiEnvironment = apiEnvironment;
         this.proxyOptions = proxyOptions;
+        this.httpTransportMode = httpTransportMode;
     }
 
     public boolean hasProxy() {
@@ -66,6 +68,7 @@ public class RequestOptions {
         private String urlBase;
         private ApiEnvironment apiEnvironment;
         private ProxyOptions proxyOptions;
+        private HttpTransportMode httpTransportMode;
 
         public RequestOptionsBuilder setToken(String token) {
             this.token = token;
@@ -97,8 +100,13 @@ public class RequestOptions {
             return this;
         }
 
+        public RequestOptionsBuilder setHttpTransportMode(HttpTransportMode httpTransportMode) {
+            this.httpTransportMode = httpTransportMode;
+            return this;
+        }
+
         public RequestOptions build() {
-            return new RequestOptions(token, sign, cuit, urlBase, apiEnvironment, proxyOptions);
+            return new RequestOptions(token, sign, cuit, urlBase, apiEnvironment, proxyOptions, httpTransportMode);
         }
     }
 
@@ -115,6 +123,7 @@ public class RequestOptions {
                 .setUrlBase(globalOptions.getUrlBase())
                 .setApiEnvironment(globalOptions.getApiEnvironment())
                 .setProxyOptions(globalOptions.getProxyOptions())
+                .setHttpTransportMode(globalOptions.getHttpTransportMode())
                 .build();
         }
 
@@ -125,6 +134,7 @@ public class RequestOptions {
             .setUrlBase(localOptions.getUrlBase() != null ? localOptions.getUrlBase() : globalOptions.getUrlBase())
             .setApiEnvironment(localOptions.getApiEnvironment() != null ? localOptions.getApiEnvironment() : globalOptions.getApiEnvironment())
             .setProxyOptions(localOptions.getProxyOptions() != null ? localOptions.getProxyOptions() : globalOptions.getProxyOptions())
+            .setHttpTransportMode(localOptions.getHttpTransportMode() != null ? localOptions.getHttpTransportMode() : globalOptions.getHttpTransportMode())
             .build();
     }
 

--- a/src/main/java/com/germanfica/wsfe/net/SoapResponseGetterOptions.java
+++ b/src/main/java/com/germanfica/wsfe/net/SoapResponseGetterOptions.java
@@ -6,4 +6,5 @@ public abstract class SoapResponseGetterOptions {
     public abstract String getUrlBase();
     public abstract ApiEnvironment getApiEnvironment();
     public abstract ProxyOptions getProxyOptions();
+    public abstract HttpTransportMode getHttpTransportMode();
 }


### PR DESCRIPTION
Introduced the `HttpTransportMode` enum to allow developers to explicitly choose between supported Apache CXF HTTP transport layers (`HTTP` and `HTTP_HC5`). This adds flexibility without sacrificing the predictability or integrity of the service-based handler design.

Key changes:
- Added `HttpTransportMode` enum with two options:
  - `HTTP` (default): uses `HttpURLConnection` via CXF’s default `HTTPConduit`.
  - `HTTP_HC5`: uses Apache HttpClient 5 via `AsyncHTTPConduit` (RFC 7235 compliant).
- Integrated transport mode selection into `RequestOptions`, `SoapResponseGetterOptions`, and client builders (`WsaaClient`, `WsfeClient`).
- Replaced implicit AsyncHTTPConduit activation with explicit activation based on the selected `HttpTransportMode`.
- Enforced `HTTP_HC5` transport when using proxies with authentication:
  - If `HTTP` is selected while using authenticated proxies, a `MissingHttpTransportSupportException` is thrown at runtime.
- Deprecated the previous `validateUnsupportedFeatures()` safeguard.

Design rationale:
- Avoids behavior-based switching tied to presence of proxy credentials.
- Respects the service-based architecture by making transport configuration declarative and explicit.
- Prevents misuse by developers while offering opt-in access to advanced features like async transport and proxy auth.

This pattern keeps the SDK predictable and easy to reason about, while enabling secure proxy integration for enterprise use cases.

Future directions:
- Support for additional transport modes (e.g., Netty, Jetty) may be added if demand arises, but are intentionally excluded for now to keep the SDK lightweight.

References:
- RFC 7235: https://datatracker.ietf.org/doc/html/rfc7235

This update builds on commit `cd74dc9f0bdd7318d31a1f1b2ac0e83e817a1120`, enhancing it with structured configurability and validation while preserving backward compatibility.