### PR TITLE
refactor: rename ApiEnvironment.TEST to HOMO for clearer ARCA (AFIP) environment semantics

### DIFF
--- a/src/main/java/com/germanfica/wsfe/examples/AuthExample.java
+++ b/src/main/java/com/germanfica/wsfe/examples/AuthExample.java
@@ -27,7 +27,7 @@ public class AuthExample {
             //WsaaClient client = WsaaClient.builder().build(); // (1)
             // Endpoint de WSAA (homologación)
             //WsaaClient client = WsaaClient.builder().setUrlBase("https://wsaa.afip.gov.ar").build();
-            //WsaaClient client = WsaaClient.builder().setApiEnvironment(ApiEnvironment.TEST).build(); // (2)
+            //WsaaClient client = WsaaClient.builder().setApiEnvironment(ApiEnvironment.HOMO).build(); // (2)
             WsaaClient client = WsaaClient.builder().setApiEnvironment(ApiEnvironment.PROD).build();
 
             // 3) Invocar autenticación en WSAA

--- a/src/main/java/com/germanfica/wsfe/examples/AuthWithProxyExample.java
+++ b/src/main/java/com/germanfica/wsfe/examples/AuthWithProxyExample.java
@@ -40,7 +40,7 @@ public class AuthWithProxyExample {
             //WsaaClient client = WsaaClient.builder().build(); // (1)
             // Endpoint de WSAA (homologación)
             //WsaaClient client = WsaaClient.builder().setUrlBase("https://wsaa.afip.gov.ar").build();
-            //WsaaClient client = WsaaClient.builder().setApiEnvironment(ApiEnvironment.TEST).build(); // (2)
+            //WsaaClient client = WsaaClient.builder().setApiEnvironment(ApiEnvironment.HOMO).build(); // (2)
             WsaaClient client = WsaaClient.builder()
                 .setApiEnvironment(ApiEnvironment.PROD)
                 .setProxyOptions(proxyOptions)

--- a/src/main/java/com/germanfica/wsfe/net/ApiEnvironment.java
+++ b/src/main/java/com/germanfica/wsfe/net/ApiEnvironment.java
@@ -6,7 +6,7 @@ import https.wsaa_afip_gov_ar.ws.services.logincms.LoginCMS;
 /** The base address to use for the request. */
 public enum ApiEnvironment {
     PROD("https://wsaa.afip.gov.ar", "https://servicios1.afip.gov.ar"),
-    TEST("https://wsaahomo.afip.gov.ar", "https://wswhomo.afip.gov.ar");
+    HOMO("https://wsaahomo.afip.gov.ar", "https://wswhomo.afip.gov.ar");
 
     private final String wsaaUrl;
     private final String wsfeUrl;


### PR DESCRIPTION
Renamed the enum constant `ApiEnvironment.TEST` to `HOMO` to better reflect standard ARCA (AFIP) terminology (`wsaahomo.afip.gov.ar`, `wswhomo.afip.gov.ar`) and avoid confusion with generic test environments.

Changes introduced:
- Renamed `ApiEnvironment.TEST` → `ApiEnvironment.HOMO`
- Updated all example references to use `ApiEnvironment.HOMO` accordingly

This change enhances clarity for developers familiar with ARCA’s (AFIP) naming conventions, making the code more intuitive and aligned with real-world environment identifiers.

Note: This is a breaking change if external code relies on `ApiEnvironment.TEST`. Consumers of the SDK should update their usage accordingly.