### PR TITLE
refactor(util): rename CMSSignedInspector to CmsSignedInspector for n…

### DIFF
--- a/src/main/java/com/germanfica/wsfe/examples/InspectSignedCmsBase64Example.java
+++ b/src/main/java/com/germanfica/wsfe/examples/InspectSignedCmsBase64Example.java
@@ -1,7 +1,7 @@
 package com.germanfica.wsfe.examples;
 
 import com.germanfica.wsfe.cms.Cms;
-import com.germanfica.wsfe.util.CMSSignedInspector;
+import com.germanfica.wsfe.util.CmsSignedInspector;
 
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -21,8 +21,8 @@ public class InspectSignedCmsBase64Example {
             String signedCmsBase64 = properties.getProperty("wsaa.cms.signed-cms-base64");
             Cms cms = Cms.create(signedCmsBase64);
 
-            CMSSignedInspector cmsSignedInspector = new CMSSignedInspector();
-            CMSSignedInspector.CmsTimestamps cmsTimestamps = cmsSignedInspector.inspect(signedCmsBase64);
+            CmsSignedInspector cmsSignedInspector = new CmsSignedInspector();
+            CmsSignedInspector.CmsTimestamps cmsTimestamps = cmsSignedInspector.inspect(signedCmsBase64);
 
             System.out.println("signingTime: " + cmsTimestamps.signingTime().toString());
             System.out.println("generationTime: "+ cmsTimestamps.generationTime().toString());

--- a/src/main/java/com/germanfica/wsfe/util/CmsSignedInspector.java
+++ b/src/main/java/com/germanfica/wsfe/util/CmsSignedInspector.java
@@ -1,7 +1,6 @@
 package com.germanfica.wsfe.util;
 
 import com.germanfica.wsfe.time.ArcaDateTime;
-import com.germanfica.wsfe.model.LoginTicketData;
 import com.germanfica.wsfe.model.LoginTicketRequestData;
 import org.bouncycastle.asn1.cms.CMSAttributes;
 
@@ -11,11 +10,9 @@ import org.bouncycastle.cms.SignerInformation;
 
 import java.nio.charset.StandardCharsets;
 import java.security.cert.X509Certificate;
-import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
 import java.util.Optional;
 
-public class CMSSignedInspector {
+public class CmsSignedInspector {
     public record CmsTimestamps(
         ArcaDateTime signingTime,
         ArcaDateTime generationTime,


### PR DESCRIPTION
…aming consistency

Renames the utility class `CMSSignedInspector` to `CmsSignedInspector` to align with standard Java naming conventions, where acronyms like 'CMS' are capitalized only at the start (e.g., 'Cms').

Also updates usage in:
- InspectSignedCmsBase64Example.java

Keeps class naming style consistent across utility components (e.g., `XmlUtils`, `XmlExtractor`).