### PR TITLE
feat(wsfe): expose feParamGetActividades method to retrieve emitter’s…

### DIFF
--- a/src/main/java/com/germanfica/wsfe/WsfeClient.java
+++ b/src/main/java/com/germanfica/wsfe/WsfeClient.java
@@ -7,6 +7,7 @@ import com.germanfica.wsfe.service.WsfeService;
 import com.germanfica.wsfe.provider.feauth.FEAuthProvider;
 import com.germanfica.wsfe.provider.ProviderChain;
 import com.germanfica.wsfe.provider.feauth.StaticAuthProvider;
+import fev1.dif.afip.gov.ar.FEActividadesResponse;
 import fev1.dif.afip.gov.ar.FECAERequest;
 import fev1.dif.afip.gov.ar.FECAEResponse;
 import fev1.dif.afip.gov.ar.FERecuperaLastCbteResponse;
@@ -41,6 +42,10 @@ public class WsfeClient {
 
     public FERecuperaLastCbteResponse feCompUltimoAutorizado(int ptoVta, int cbteTipo) throws ApiException {
         return new com.germanfica.wsfe.service.WsfeService(soapRequestHandler, authProvider).feCompUltimoAutorizado(ptoVta, cbteTipo);
+    }
+
+    public FEActividadesResponse feParamGetActividades() throws ApiException {
+        return new com.germanfica.wsfe.service.WsfeService(soapRequestHandler, authProvider).feParamGetActividades();
     }
 
     static class ClientWsfeResponseGetterOptions extends SoapResponseGetterOptions {

--- a/src/main/java/com/germanfica/wsfe/examples/ConsultarActividadesVigentesExample.java
+++ b/src/main/java/com/germanfica/wsfe/examples/ConsultarActividadesVigentesExample.java
@@ -1,0 +1,81 @@
+package com.germanfica.wsfe.examples;
+
+import com.germanfica.wsfe.WsaaClient;
+import com.germanfica.wsfe.WsfeClient;
+import com.germanfica.wsfe.exception.ApiException;
+import com.germanfica.wsfe.net.ApiEnvironment;
+import com.germanfica.wsfe.provider.feauth.RefreshingAuthProvider;
+import fev1.dif.afip.gov.ar.ActividadesTipo;
+import fev1.dif.afip.gov.ar.Err;
+import fev1.dif.afip.gov.ar.Evt;
+import fev1.dif.afip.gov.ar.FEActividadesResponse;
+
+/**
+ * Ejemplo de cómo consultar las actividades vigentes del emisor (CUIT)
+ * usando el método {@code FEParamGetActividades} del WSFEv1.
+ * <p>
+ * Según la RG 5259/2022 y RG 5264/2022, este método devuelve
+ * las actividades declaradas por el emisor. En homologación
+ * puede devolver "Sin resultados" si el CUIT de prueba
+ * no tiene actividades cargadas en el ambiente de test.
+ * </p>
+ */
+public class ConsultarActividadesVigentesExample {
+    /**
+     * Punto de entrada del ejemplo.
+     * <ol>
+     *   <li>Inicializa el cliente WSAA para autenticación.</li>
+     *   <li>Construye el cliente WSFE con autenticación de autorenovación.</li>
+     *   <li>Llama a {@code feParamGetActividades} y muestra en consola:</li>
+     *   <ul>
+     *     <li>Errores (si los hay).</li>
+     *     <li>Eventos (si los hay).</li>
+     *     <li>Listado de actividades vigentes.</li>
+     *   </ul>
+     * </ol>
+     *
+     * @throws ApiException si falla la llamada al Web Service
+     */
+    public static void main(String[] args) throws ApiException {
+        // 1) Crear el WsaaClient
+        WsaaClient wsaaClient = WsaaClient.builder()
+            .setApiEnvironment(ApiEnvironment.HOMO)
+            .build();
+
+        // 2) Crear el WsfeClient
+        WsfeClient client = WsfeClient.builder()
+            .setApiEnvironment(ApiEnvironment.HOMO)
+            .setFEAuthProvider(new RefreshingAuthProvider(wsaaClient))
+            .build();
+
+        // 3) Consultar
+        FEActividadesResponse response = client.feParamGetActividades();
+
+        // Imprimir errores si existen
+        if (response.getErrors() != null && response.getErrors().getErr() != null) {
+            System.out.println("Errores:");
+            for (Err err : response.getErrors().getErr()) {
+                System.out.printf("  Código: %d - Mensaje: %s%n", err.getCode(), err.getMsg());
+            }
+        }
+
+        // Imprimir eventos si existen
+        if (response.getEvents() != null && response.getEvents().getEvt() != null) {
+            System.out.println("Eventos:");
+            for (Evt evt : response.getEvents().getEvt()) {
+                System.out.printf("  Código: %d - Mensaje: %s%n", evt.getCode(), evt.getMsg());
+            }
+        }
+
+        // Imprimir actividades vigentes
+        if (response.getResultGet() != null && response.getResultGet().getActividadesTipo() != null) {
+            System.out.println("Actividades vigentes:");
+            for (ActividadesTipo actividad : response.getResultGet().getActividadesTipo()) {
+                System.out.printf("  ID: %d - Orden: %d - Descripción: %s%n",
+                    actividad.getId(), actividad.getOrden(), actividad.getDesc());
+            }
+        } else {
+            System.out.println("No se encontraron actividades vigentes.");
+        }
+    }
+}

--- a/src/main/java/com/germanfica/wsfe/service/WsfeService.java
+++ b/src/main/java/com/germanfica/wsfe/service/WsfeService.java
@@ -22,6 +22,10 @@ public class WsfeService extends ApiService {
         return invoke(null, ServiceSoap.class, port -> port.feCompUltimoAutorizado(authProvider.getAuth(), ptoVta, cbteTipo));
     }
 
+    public FEActividadesResponse feParamGetActividades() throws ApiException {
+        return invoke(null, ServiceSoap.class, port -> port.feParamGetActividades(authProvider.getAuth()));
+    }
+
     /**
      * Obtiene el último comprobante autorizado para un punto de venta y tipo de comprobante específicos.
      * @param ptoVta Punto de venta


### PR DESCRIPTION
… active activities

This commit adds support for the `FEParamGetActividades` operation introduced in RG 5259/2022 and RG 5264/2022. This method allows querying the set of activities currently declared and active for the emitter CUIT.

Changes include:
- A new method `feParamGetActividades()` in `WsfeClient` and `WsfeService`
- A new example class `ConsultarActividadesVigentesExample` demonstrating how to invoke this operation
- Detailed JavaDocs to clarify that this method returns the emitter’s activities (not a general catalog), and that in the HOMO environment, a "No results" response is expected unless activities are preloaded for the CUIT

This improves SDK coverage of recent WSFE changes and helps developers ensure that invoices reference valid declared activities, especially for remitos cárnicos and harineros subject to stricter validations.

References:
- RG 5259/2022 and RG 5264/2022
- WSFEv1 official documentation updated as of June 2025