### PR TITLE
examples: split AuthWithSignedCmsBase64Example into homo/ and prod/ s…

### DIFF
--- a/src/main/java/com/germanfica/wsfe/examples/homo/AuthWithSignedCmsBase64Example.java
+++ b/src/main/java/com/germanfica/wsfe/examples/homo/AuthWithSignedCmsBase64Example.java
@@ -1,0 +1,38 @@
+package com.germanfica.wsfe.examples.homo;
+
+import com.germanfica.wsfe.WsaaClient;
+import com.germanfica.wsfe.cms.Cms;
+import com.germanfica.wsfe.model.LoginTicketResponseData;
+import com.germanfica.wsfe.net.ApiEnvironment;
+import com.germanfica.wsfe.util.LoginTicketParser;
+
+public class AuthWithSignedCmsBase64Example {
+    public static void main(String[] args) {
+        try {
+            // 1) Armar CMS para WSAA
+            Cms cms = Cms.create("your-signed-cms-base64");
+
+            // 2) Crear el WsfeClient
+            //WsaaClient client = WsaaClient.builder().build(); // (1)
+            // Endpoint de WSAA (homologación)
+            //WsaaClient client = WsaaClient.builder().setUrlBase("https://wsaahomo.afip.gov.ar").build();
+            WsaaClient client = WsaaClient.builder().setApiEnvironment(ApiEnvironment.HOMO).build();
+
+            // 3) Invocar autenticación en WSAA
+            String authResponse = client.authService().autenticar(cms);
+
+            LoginTicketResponseData data = (LoginTicketResponseData) LoginTicketParser.parse(authResponse);
+
+            // 4) Imprimir resultado
+            System.out.println("Respuesta de autenticación xml: \n" + authResponse);
+            System.out.println("Respuesta de autenticación json: \n" + data);
+            System.out.println("Token: \n" + data.token());
+            System.out.println("Sign: \n" + data.sign());
+            System.out.println("generationTime: \n" + data.generationTime());
+            System.out.println("expirationTime: \n" + data.expirationTime());
+        } catch (Exception e) {
+            System.err.println("Error al invocar autenticación WSAA: " + e.getMessage());
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/main/java/com/germanfica/wsfe/examples/prod/AuthWithSignedCmsBase64Example.java
+++ b/src/main/java/com/germanfica/wsfe/examples/prod/AuthWithSignedCmsBase64Example.java
@@ -1,4 +1,4 @@
-package com.germanfica.wsfe.examples;
+package com.germanfica.wsfe.examples.prod;
 
 import com.germanfica.wsfe.WsaaClient;
 import com.germanfica.wsfe.cms.Cms;
@@ -16,7 +16,6 @@ public class AuthWithSignedCmsBase64Example {
             //WsaaClient client = WsaaClient.builder().build(); // (1)
             // Endpoint de WSAA (homologación)
             //WsaaClient client = WsaaClient.builder().setUrlBase("https://wsaa.afip.gov.ar").build();
-            //WsaaClient client = WsaaClient.builder().setApiEnvironment(ApiEnvironment.HOMO).build(); // (2)
             WsaaClient client = WsaaClient.builder().setApiEnvironment(ApiEnvironment.PROD).build();
 
             // 3) Invocar autenticación en WSAA


### PR DESCRIPTION
…ubpackages

Motivation:
- Provide clear separation of examples using signed CMS Base64 for both homologation and production environments.
- Eliminate commented-out lines and manual switching that could confuse developers.

Changes:
- Added new 'examples.homo.AuthWithSignedCmsBase64Example' configured with ApiEnvironment.HOMO and WSAA homologation endpoint.
- Moved original example into 'examples.prod.AuthWithSignedCmsBase64Example' configured with ApiEnvironment.PROD and WSAA production endpoint.
- Documented both homologation and production WSAA endpoints as comments for reference.

Impact:
- Developers can now directly run either homo or prod version without editing code.
- Improves clarity and plug-and-play usage for Base64 CMS authentication.