### PR TITLE
examples: move ConsultarActividadesVigentesExample to homo subpackage

### DIFF
--- a/src/main/java/com/germanfica/wsfe/examples/homo/ConsultarActividadesVigentesExample.java
+++ b/src/main/java/com/germanfica/wsfe/examples/homo/ConsultarActividadesVigentesExample.java
@@ -1,4 +1,4 @@
-package com.germanfica.wsfe.examples;
+package com.germanfica.wsfe.examples.homo;
 
 import com.germanfica.wsfe.WsaaClient;
 import com.germanfica.wsfe.WsfeClient;


### PR DESCRIPTION
- Relocated ConsultarActividadesVigentesExample into 'com.germanfica.wsfe.examples.homo'.
- Updated package declaration accordingly.
- Keeps example aligned with homologation environment usage.