### PR TITLE
examples: move FECAESolicitarExample into homo/ subpackage

### DIFF
--- a/src/main/java/com/germanfica/wsfe/examples/homo/FECAESolicitarExample.java
+++ b/src/main/java/com/germanfica/wsfe/examples/homo/FECAESolicitarExample.java
@@ -1,7 +1,8 @@
-package com.germanfica.wsfe.examples;
+package com.germanfica.wsfe.examples.homo;
 
 import com.germanfica.wsfe.WsfeClient;
 import com.germanfica.wsfe.exception.ApiException;
+import com.germanfica.wsfe.net.ApiEnvironment;
 import com.germanfica.wsfe.param.FEAuthParams;
 import com.germanfica.wsfe.provider.CredentialsProvider;
 import com.germanfica.wsfe.provider.feauth.ApplicationPropertiesFeAuthParamsProvider;


### PR DESCRIPTION
- Relocated FECAESolicitarExample from 'examples' into 'examples.homo' package.
- Added ApiEnvironment import to allow explicit environment selection.
- Keeps example aligned with homologation environment usage.

Next steps:
- Provide a mirrored version under 'examples.prod' for production environment consistency.