### PR TITLE
examples: update FECAESolicitarExample to explicitly use HOMO environ…

### DIFF
--- a/src/main/java/com/germanfica/wsfe/examples/homo/FECAESolicitarExample.java
+++ b/src/main/java/com/germanfica/wsfe/examples/homo/FECAESolicitarExample.java
@@ -20,7 +20,10 @@ public class FECAESolicitarExample {
         int cbteTipo = 11;
 
         // 3) Crear el WsfeClient
-        WsfeClient client = WsfeClient.builder().setFEAuthParams(auth).build();
+        WsfeClient client = WsfeClient.builder()
+            .setApiEnvironment(ApiEnvironment.HOMO)
+            .setFEAuthParams(auth)
+            .build();
 
         // 4) Cabecera FECAECabRequest
         FECAECabRequest cab = new FECAECabRequest();


### PR DESCRIPTION
…ment

- Added explicit call to setApiEnvironment(ApiEnvironment.HOMO) in homo/FECAESolicitarExample.
- Keeps consistency with other homo examples where the environment is clearly defined.
- Ensures developers understand the target environment without relying on defaults.