### PR TITLE
examples: move ConsultarActividadesVigentesExample into homo subpackage

### DIFF
--- a/src/main/java/com/germanfica/wsfe/examples/homo/ConsultarActividadesVigentesExample.java
+++ b/src/main/java/com/germanfica/wsfe/examples/homo/ConsultarActividadesVigentesExample.java
@@ -1,4 +1,4 @@
-package com.germanfica.wsfe.examples;
+package com.germanfica.wsfe.examples.homo;
 
 import com.germanfica.wsfe.WsaaClient;
 import com.germanfica.wsfe.WsfeClient;


### PR DESCRIPTION
- Relocated ConsultarActividadesVigentesExample from 'examples' into 'examples.homo'.
- Keeps example aligned with homologation environment usage.