### PR TITLE
examples: move FECompUltimoAutorizadoExample into homo subpackage

### DIFF
--- a/src/main/java/com/germanfica/wsfe/examples/homo/FECompUltimoAutorizadoExample.java
+++ b/src/main/java/com/germanfica/wsfe/examples/homo/FECompUltimoAutorizadoExample.java
@@ -1,4 +1,4 @@
-package com.germanfica.wsfe.examples;
+package com.germanfica.wsfe.examples.homo;
 
 import com.germanfica.wsfe.WsfeClient;
 import com.germanfica.wsfe.exception.ApiException;


### PR DESCRIPTION
- Relocated FECompUltimoAutorizadoExample from 'examples' into 'examples.homo' package.
- Keeps example aligned with homologation environment usage.