### PR TITLE
fix(auth): prevent returning expired TA from disk cache

### DIFF
--- a/src/main/java/com/germanfica/wsfe/provider/feauth/RefreshingAuthProvider.java
+++ b/src/main/java/com/germanfica/wsfe/provider/feauth/RefreshingAuthProvider.java
@@ -48,7 +48,7 @@ public class RefreshingAuthProvider implements FEAuthProvider {
             .resolve()
             .orElse(null);
 
-        if (cache != null) return;  // TA vigente, no hace nada
+        if (cache != null && !cache.isExpired()) return;  // TA vigente, no hace nada
 
         // (2) No había TA o estaba vencido -> pedir uno nuevo a WSAA
         Cms cms = buildCmsAutomatically();


### PR DESCRIPTION
Previously, `RefreshingAuthProvider.refresh()` returned any cached FEAuthParams loaded from disk without validating its expiration. This resulted in passing expired tokens to ARCA/AFIP, which caused `Error 600: ValidacionDeToken` rejections.

Confusion arose because `getAuth()` already checks `isExpired()` for the in-memory cache, but the same validation was missing for the disk-backed provider. This hidden bug allowed stale credentials to bypass the intended refresh flow.

This change fixes the bug by ensuring that only non-expired tokens are reused from disk.

If the TA is expired, a new CMS will be built and a fresh token obtained from WSAA, as originally intended.

This is a critical fix because without it, expired disk tokens were silently reused and requests to WSFE consistently failed.