### PR TITLE
fix(test): update SoapEnvelopeTest to use XML-based parsing instead o…

### DIFF
--- a/src/test/java/com/germanfica/SoapEnvelopeTest.java
+++ b/src/test/java/com/germanfica/SoapEnvelopeTest.java
@@ -2,6 +2,8 @@ package com.germanfica;
 
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import com.germanfica.wsfe.exception.XmlMappingException;
+import com.germanfica.wsfe.model.LoginTicketResponseData;
+import com.germanfica.wsfe.util.LoginTicketParser;
 import com.germanfica.wsfe.util.XmlExtractor;
 import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBException;
@@ -31,14 +33,14 @@ public class SoapEnvelopeTest {
                 """;
 
         XmlExtractor extractor = new XmlExtractor(xmlResponse);
-        String token = extractor.extractValue("/ loginTicketResponse/ credentials/ token");
-        XmlExtractor. LoginTicketData data = extractor. extractLoginTicketData();
+        String token = extractor.extractValue("/loginTicketResponse/credentials/token");
+        LoginTicketResponseData data = (LoginTicketResponseData) LoginTicketParser.parse(xmlResponse);
 
         // Imprimir resultados
         System.out.println("Respuesta de autenticación xml: \n" + xmlResponse);
-        System.out.println("Respuesta de autenticación json: \n" + data);
-        System.out.println("\nRespuesta de token json: \n" + data.token);
-        System.out.println("\nToken: \n" + token);
+        System.out.println("Respuesta de autenticación (parseada): \n" + data);
+        System.out.println("\nRespuesta de LoginTicketResponseData: \n" + data.token());
+        System.out.println("\nToken extraído con XPath: \n" + token);
     }
 
     /**


### PR DESCRIPTION
…f Gson

Previously, the test referred to "authentication json" and "token json" outputs, which were misleading since Gson is no longer used. The test now uses the LoginTicketParser to parse the XML response directly into LoginTicketResponseData, and the printed messages have been updated accordingly.

This change aligns with ARCA/AFIP's recommendation to handle WSAA responses using the raw XML data instead of JSON conversions, avoiding any potential signature corruption or parsing inconsistencies that Gson could introduce. The test now reflects the new XML-first approach and ensures consistency with the robust LoginTicketResponseData model.

Files updated:
- SoapEnvelopeTest.java