### PR TITLE
refactor(feauth): simplify RefreshingAuthProvider to trust WSAA expir…

### DIFF
--- a/src/main/java/com/germanfica/wsfe/provider/cms/FileSignedCmsProvider.java
+++ b/src/main/java/com/germanfica/wsfe/provider/cms/FileSignedCmsProvider.java
@@ -32,6 +32,7 @@ import java.util.Optional;
  *     .build();
  * }</pre>
  */
+@Deprecated
 public final class FileSignedCmsProvider implements CredentialsProvider<String> {
 
     /* ~/.wsfe/cms.ini */
@@ -42,6 +43,7 @@ public final class FileSignedCmsProvider implements CredentialsProvider<String> 
     private static final String KEY     = "signedCms";
 
     @Override
+    @Deprecated
     public Optional<String> resolve() {
         try {
             if (!Files.exists(CMS_FILE)) return Optional.empty();
@@ -75,6 +77,7 @@ public final class FileSignedCmsProvider implements CredentialsProvider<String> 
      * @param signedCmsBase64 CMS firmado en Base64.
      * @throws IllegalArgumentException si el valor es nulo o vacío.
      */
+    @Deprecated
     public static void save(String signedCmsBase64) {
         if (signedCmsBase64 == null || signedCmsBase64.isBlank()) {
             throw new IllegalArgumentException("signedCmsBase64 vacío o nulo");

--- a/src/main/java/com/germanfica/wsfe/provider/feauth/RefreshingAuthProvider.java
+++ b/src/main/java/com/germanfica/wsfe/provider/feauth/RefreshingAuthProvider.java
@@ -14,12 +14,25 @@ import com.germanfica.wsfe.provider.cms.EnvironmentCmsParamsProvider;
 import com.germanfica.wsfe.provider.cms.FileSignedCmsProvider;
 import com.germanfica.wsfe.provider.cms.SystemPropertyCmsParamsProvider;
 import com.germanfica.wsfe.time.ArcaDateTime;
-import com.germanfica.wsfe.util.*;
+import com.germanfica.wsfe.util.LoginTicketParser;
 import fev1.dif.afip.gov.ar.FEAuthRequest;
 
+/**
+ * RefreshingAuthProvider
+ *
+ * Implementa la política de renovación del Ticket de Acceso (TA) según WSAA.
+ *
+ * - Solo el TA (FEAuthParams) se persiste y se reutiliza entre ejecuciones.
+ * - Cada vez que se requiere un TA nuevo, se genera un CMS fresco
+ *   (basado en un nuevo TRA firmado con el certificado digital).
+ *
+ * Este proveedor confía íntegramente en los tiempos devueltos por el WSAA
+ * dentro del <loginTicketResponse>.
+ */
 public class RefreshingAuthProvider implements FEAuthProvider {
-    private final WsaaClient wsaa;            // WSAA
-    private volatile FEAuthParams cache;               // TA cacheado mientras no expire
+
+    private final WsaaClient wsaa;       // Cliente WSAA
+    private volatile FEAuthParams cache; // TA cacheado mientras no expire
 
     public RefreshingAuthProvider(WsaaClient wsaa) {
         this.wsaa = wsaa;
@@ -41,7 +54,7 @@ public class RefreshingAuthProvider implements FEAuthProvider {
     }
 
     private void refresh() throws ApiException {
-        // (1) Intenta cargar un TA válido desde disco
+        // (1) Intentar reutilizar TA válido persistido en disco
         cache = ProviderChain.<FEAuthParams>builder()
             .addProvider(new FileFEAuthParamsProvider())
             .build()
@@ -51,7 +64,7 @@ public class RefreshingAuthProvider implements FEAuthProvider {
         if (cache != null && !cache.isExpired()) return;  // TA vigente, no hace nada
 
         // (2) No había TA o estaba vencido -> pedir uno nuevo a WSAA
-        Cms cms = buildCmsAutomatically();
+        Cms cms = buildFreshCms();
         String xml = wsaa.authService().autenticar(cms);
 
         try {
@@ -64,6 +77,7 @@ public class RefreshingAuthProvider implements FEAuthProvider {
                 .setGenerationTime(ArcaDateTime.parse(data.generationTime()))
                 .setExpirationTime(ArcaDateTime.parse(data.expirationTime()))
                 .build();
+
         } catch (Exception e) {
             throw new ApiException(
                 new ErrorDto("invalid_xml", "No se pudo parsear loginTicketResponse", null),
@@ -71,16 +85,19 @@ public class RefreshingAuthProvider implements FEAuthProvider {
             );
         }
 
-        // (3) Persistir en disco para la próxima ejecución
+        // (3) Persistir nuevo TA
         FileFEAuthParamsProvider.save(cache);
     }
 
     /**
-      * Genera un nuevo CMS (y con él su Subject CUIT) cada vez que necesitemos
-      * refrescar el Ticket de Acceso.  Si tu certificado tiene una validez de
-      * ~2 años y prefieres reutilizarlo, puedes cachear el {@code Cms} aquí del
-      * mismo modo que el TA (cache) —quedó listo para añadir esa optimización.
-      */
+     * Genera un nuevo CMS (y con él su Subject CUIT) cada vez que necesitemos
+     * refrescar el Ticket de Acceso.  Si tu certificado tiene una validez de
+     * ~2 años y prefieres reutilizarlo, puedes cachear el {@code Cms} aquí del
+     * mismo modo que el TA (cache) —quedó listo para añadir esa optimización.
+     *
+     * @deprecated Use {@link #buildFreshCms()} instead.
+     */
+    @Deprecated
     private Cms buildCmsAutomatically() {
         String signedCmsBase64 = ProviderChain.<String>builder()
             .addProvider(new FileSignedCmsProvider())      // primero busca en el archivo
@@ -103,6 +120,23 @@ public class RefreshingAuthProvider implements FEAuthProvider {
             });
 
         return Cms.create(signedCmsBase64);
+    }
+
+    /**
+     * Genera siempre un CMS fresco firmado con el certificado configurado.
+     * El CMS no se persiste, ya que su vigencia depende del TRA generado
+     * dentro de la misma operación de solicitud de TA.
+     */
+    private Cms buildFreshCms() {
+        CmsParams cmsParams = ProviderChain.<CmsParams>builder()
+            .addProvider(new EnvironmentCmsParamsProvider())
+            .addProvider(new SystemPropertyCmsParamsProvider())
+            .addProvider(new ApplicationPropertiesCmsParamsProvider())
+            .build()
+            .resolve()
+            .orElseThrow(() -> new IllegalStateException("No se pudieron resolver CmsParams"));
+
+        return Cms.create(cmsParams);
     }
 
     private static FEAuthRequest toFEAuthRequest(FEAuthParams p) {

--- a/src/main/java/com/germanfica/wsfe/provider/feauth/RefreshingAuthProvider.java
+++ b/src/main/java/com/germanfica/wsfe/provider/feauth/RefreshingAuthProvider.java
@@ -91,9 +91,7 @@ public class RefreshingAuthProvider implements FEAuthProvider {
 
     /**
      * Genera un nuevo CMS (y con él su Subject CUIT) cada vez que necesitemos
-     * refrescar el Ticket de Acceso.  Si tu certificado tiene una validez de
-     * ~2 años y prefieres reutilizarlo, puedes cachear el {@code Cms} aquí del
-     * mismo modo que el TA (cache) —quedó listo para añadir esa optimización.
+     * refrescar el Ticket de Acceso.
      *
      * @deprecated Use {@link #buildFreshCms()} instead.
      */


### PR DESCRIPTION
…ation times

This refactor removes unnecessary skew and pre-refresh logic from `RefreshingAuthProvider`, aligning the implementation with the official WSAA specification.

- Relies solely on expiration timestamps provided by ARCA/AFIP servers.
- Simplifies expiration checks to `isExpired()` in `FEAuthParams`.
- Introduces `buildFreshCms()` to explicitly regenerate CMS each renewal.
- Marks `buildCmsAutomatically()` as deprecated.
- Clarifies Javadoc to reflect WSAA's responsibility for TA lifetime.

The provider now fully trusts WSAA's <loginTicketResponse> timings, ensuring predictable and specification-compliant renewal behavior.