### PR TITLE
refactor(wsfe-service): remove unused experimental helper method

### DIFF
--- a/src/main/java/com/germanfica/wsfe/service/WsfeService.java
+++ b/src/main/java/com/germanfica/wsfe/service/WsfeService.java
@@ -25,14 +25,4 @@ public class WsfeService extends ApiService {
     public FEActividadesResponse feParamGetActividades() throws ApiException {
         return invoke(null, ServiceSoap.class, port -> port.feParamGetActividades(authProvider.getAuth()));
     }
-
-    /**
-     * Obtiene el último comprobante autorizado para un punto de venta y tipo de comprobante específicos.
-     * @param ptoVta Punto de venta
-     * @param cbteTipo Tipo de comprobante (Ej: 11 para Factura C)
-     * @return Número del último comprobante autorizado
-     */
-    public int obtenerUltimoComprobante(int ptoVta, int cbteTipo) throws ApiException {
-        return invoke(null, ServiceSoap.class, port -> port.feCompUltimoAutorizado(authProvider.getAuth(), ptoVta, cbteTipo).getCbteNro());
-    }
 }


### PR DESCRIPTION
Remove the obsolete helper method `obtenerUltimoComprobante` from `WsfeService`. This method was originally added as a one-time experiment and is no longer used.

Developers should rely on the officially exposed API methods instead of creating custom derived helpers. Keeping only the supported methods ensures better consistency and maintainability across the service layer.