### PR TITLE
feat: allow custom TRA expiration via ticketTimeMillis parameter

### DIFF
--- a/src/main/java/com/germanfica/wsfe/model/LoginTicketRequest.java
+++ b/src/main/java/com/germanfica/wsfe/model/LoginTicketRequest.java
@@ -97,7 +97,7 @@ public class LoginTicketRequest {
         }
     }
 
-    public static LoginTicketRequest create(String source, String destination, String service, long ticketTimeMillis) {
+    public static LoginTicketRequest create(String source, String destination, String service, Long ticketTimeMillis) {
         LoginTicketRequest request = new LoginTicketRequest();
 
         Header header = new Header();
@@ -106,7 +106,13 @@ public class LoginTicketRequest {
         header.setUniqueId(String.valueOf(System.currentTimeMillis() / 1000));
 
         ArcaDateTime generationTime = ArcaDateTime.now();
-        ArcaDateTime expirationTime = ArcaDateTime.now().plusMinutes(10);
+        ArcaDateTime expirationTime;
+
+        if (ticketTimeMillis != null && ticketTimeMillis > 0) {
+            expirationTime = generationTime.plusMillis(ticketTimeMillis);
+        }else {
+            expirationTime = ArcaDateTime.now().plusMinutes(10);
+        }
 
         header.setGenerationTime(generationTime.toString());
         header.setExpirationTime(expirationTime.toString());


### PR DESCRIPTION
This update modifies the LoginTicketRequest.create method to accept a Long ticketTimeMillis parameter, enabling the generation of LoginTicketRequests with a custom expiration time. The value of ticketTimeMillis is now used to calculate the expirationTime of the TRA, allowing greater flexibility for clients that require specific session lifetimes.

If no value is provided or the value is zero, the method defaults to a 10-minute expiration period to preserve existing behavior.