### PR TITLE
feat(time): add Clock-based now() support in ArcaDateTime

### DIFF
--- a/src/main/java/com/germanfica/wsfe/time/ArcaDateTime.java
+++ b/src/main/java/com/germanfica/wsfe/time/ArcaDateTime.java
@@ -37,6 +37,10 @@ public final class ArcaDateTime implements Serializable {
         return new ArcaDateTime(OffsetDateTime.now());
     }
 
+    public static ArcaDateTime now(Clock clock) {
+        return of(clock.instant());
+    }
+
     public static ArcaDateTime of(OffsetDateTime value) {
         return new ArcaDateTime(value);
     }


### PR DESCRIPTION
Added support for creating ArcaDateTime instances using a Clock parameter, mirroring the behavior of standard Java time classes like LocalDate, LocalTime, and LocalDateTime.

Unlike those classes, ArcaDateTime ensures that the resulting date-time is always expressed with the Argentina time offset (-03:00), as required by the ARCA specification.

This change allows deterministic and testable time creation (via Clock) while preserving the invariant that all ArcaDateTime instances remain anchored to the -03:00 offset.