### PR TITLE
docs(readme): add example for adding SDK as a dependency in another p…

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,16 @@ or
 mvn clean package -DskipTests install:install-file -Dfile=target/wsfe-0.0.1-SNAPSHOT.jar -DgroupId=com.germanfica -DartifactId=wsfe -Dversion=0.0.1-SNAPSHOT -Dpackaging=jar
 ```
 
+(3) After that, you can add the dependency in another project:
+
+```xml
+<dependency>
+  <groupId>com.germanfica</groupId>
+  <artifactId>wsfe-sdk</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+</dependency>
+```
+
 ## Docs
 
 - https://www.mojohaus.org/jaxb2-maven-plugin/Documentation/v3.1.0/index.html


### PR DESCRIPTION
…roject

Add a clear XML example showing how to include the SDK in another project's pom.xml after installing it to the local Maven repository. This helps developers quickly understand how to consume the package without guessing groupId, artifactId, or version details.